### PR TITLE
feat: Implement multiple hex map enhancements

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -22,6 +22,11 @@ export const PaintMode = {
   FEATURE: 'feature',
 };
 
+export const FeatureBrushAction = {
+    ADD: 'add',
+    REMOVE: 'remove'
+};
+
 export const TerrainFeature = {
   NONE: 'none',
   LANDMARK: 'LANDMARK',
@@ -250,6 +255,7 @@ export const HEX_3D_PROJECTED_DEPTH_PER_ELEVATION_UNIT = 0.05;
 export const HEX_3D_Y_SQUASH_FACTOR = 1.0;
 export const HEX_3D_SIDE_COLOR_DARKEN_FACTOR = 0.25;
 export const HEX_3D_MIN_VISUAL_DEPTH = 1.5;
+export const HEX_PREVIEW_STROKE_WIDTH_ADDITION = 1.5;
 
 // Config for auto terrain change based on elevation
 export const AUTO_TERRAIN_CHANGE_ENABLED_DEFAULT = true; // New constant

--- a/app/state.js
+++ b/app/state.js
@@ -32,9 +32,11 @@ export const appState = {
   autoTerrainChangeOnElevation: CONST.AUTO_TERRAIN_CHANGE_ENABLED_DEFAULT, // New state for toggle
 
   paintMode: CONST.PaintMode.ELEVATION,
+  featureBrushAction: CONST.FeatureBrushAction.ADD,
   brushSize: CONST.DEFAULT_BRUSH_SIZE,
   selectedTerrainType: CONST.DEFAULT_TERRAIN_TYPE,
   selectedFeatureType: CONST.TerrainFeature.NONE,
+  brushPreviewHexIds: new Set(),
 
   editorLosSourceHexId: null,
   editorVisibleHexIds: new Set(),

--- a/app/templates/controls.hbs
+++ b/app/templates/controls.hbs
@@ -162,6 +162,22 @@
             <option value="{{this}}" {{#if (eq ../selectedFeatureType this)}}selected{{/if}}>{{capitalizeFirst this}}</option>
           {{/each}}
         </select>
+        <div class="grid grid-cols-2 gap-1.5 mt-1.5">
+          <button id="featureAddModeButton"
+                  data-action="set-feature-brush-action"
+                  data-feature-action="{{@root.CONST.FeatureBrushAction.ADD}}"
+                  class="px-2 py-1 text-xs border rounded {{#if (eq @root.featureBrushAction @root.CONST.FeatureBrushAction.ADD)}}bg-green-500 text-white{{else}}bg-gray-600 text-gray-200 hover:bg-gray-500{{/if}}"
+                  title="Add features with brush (selected type)">
+            Add Mode
+          </button>
+          <button id="featureRemoveModeButton"
+                  data-action="set-feature-brush-action"
+                  data-feature-action="{{@root.CONST.FeatureBrushAction.REMOVE}}"
+                  class="px-2 py-1 text-xs border rounded {{#if (eq @root.featureBrushAction @root.CONST.FeatureBrushAction.REMOVE)}}bg-red-500 text-white{{else}}bg-gray-600 text-gray-200 hover:bg-gray-500{{/if}}"
+                  title="Remove features with brush">
+            Remove Mode
+          </button>
+        </div>
       {{/if}}
 
       {{!-- LoS Tools --}}

--- a/app/templates/hexagon.hbs
+++ b/app/templates/hexagon.hbs
@@ -4,10 +4,11 @@
 
   <polygon
     points="{{this.points}}"
-    class="{{#if this.isTailwindFill}}{{this.currentFillColor}}{{/if}} {{this.finalStrokeColor}} group-hover:stroke-white transition-all duration-150"
-    style="{{#unless this.isTailwindFill}}fill: {{this.currentFillColor}};{{/unless}}"
-    stroke-width="{{this.finalStrokeWidth}}"
-  />
+    class="{{this.hexOpacityClass}} {{#if this.isBrushPreview}}stroke-blue-400{{else}}{{this.finalStrokeColor}}{{/if}} {{#if this.isBrushPreview}}opacity-100 stroke-[{{add @root.CONST.HEX_PREVIEW_STROKE_WIDTH_ADDITION this.finalStrokeWidth "1"}}]{{else}}stroke-[{{this.finalStrokeWidth}}]{{/if}} group-hover:stroke-white transition-all duration-150"
+    fill="{{#unless this.isTailwindFill}}{{this.currentFillColor}}{{/unless}}"
+    style="{{#if this.isTailwindFill}}fill:currentColor; color:{{this.currentFillColor}};{{/if}}"
+    />
+    {{!-- stroke-width attribute removed as it's handled by Tailwind stroke-[value] now --}}
 
   {{#unless this.isTextHiddenForPlayer}}
     {{#if this.elevationText}}


### PR DESCRIPTION
This commit introduces several new features and improvements to the hex map functionality:

1.  **Standalone Landmark Prompts:**
    - When adding landmarks/secrets due to encounters, discoveries, or brush use in standalone mode, you are now prompted for Name, Icon, and Icon Color using browser prompts.

2.  **Brush-Based Landmark Removal:**
    - A "Remove Mode" has been added to the feature brush. When active, clicking on hexes removes existing landmarks or secrets.

3.  **Multi-Hex Brush Landmark Application:**
    - When using the feature brush (Add Mode) for Landmarks/Secrets with a brush size greater than 1, details are prompted once.
    - The same landmark/secret (name, icon, color) is then applied to all hexes affected by the brush.

4.  **Brush Size Preview:**
    - A visual preview of the brush's area of effect is now displayed when hovering over the map in Hex Editor mode with an active paint tool.
    - Previewed hexes are highlighted with a distinct stroke color and increased stroke width.

5.  **Merge Landmark/Secret Details:**
    - When adding a landmark/secret to a hex that already contains one of the same type: - The `featureName` (description) is merged (e.g., "Old Name / New Name"). - The `featureIcon` and `featureIconColor` are updated to the newly provided ones from the prompt.
    - This merge logic works for both single-hex and multi-hex brush applications.

These changes enhance the usability and functionality of the hex map editor, particularly for standalone users and for more complex editing tasks.