### PR TITLE
fix: Correct syntax error in app/constants.js

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -259,10 +259,10 @@ export const HEX_PREVIEW_STROKE_WIDTH_ADDITION = 1.5;
 
 // Config for auto terrain change based on elevation
 export const AUTO_TERRAIN_CHANGE_ENABLED_DEFAULT = true; // New constant
-export const AUTO_TERRAIN_IGNORE_TYPES = [ // Types not to change automatically
-    TerrainType.ROAD, TerrainType.SETTLEMENT, TerrainType.WATER,
 // Weather System Constants
 export const WEATHER_UPDATE_INTERVAL_HOURS = 12;
+export const AUTO_TERRAIN_IGNORE_TYPES = [ // Types not to change automatically
+    TerrainType.ROAD, TerrainType.SETTLEMENT, TerrainType.WATER,
     TerrainType.SHALLOW_WATER, TerrainType.DEEP_OCEAN,
     TerrainType.CAVERN_FLOOR, TerrainType.TUNNEL, TerrainType.MUSHROOM_FOREST,
     TerrainType.CRYSTAL_CAVE, TerrainType.UNDERGROUND_RIVER, TerrainType.LAVA_TUBE,


### PR DESCRIPTION
The WEATHER_UPDATE_INTERVAL_HOURS constant was incorrectly defined inside the AUTO_TERRAIN_IGNORE_TYPES array. This commit moves the constant definition to its correct place, resolving the syntax error.