### PR TITLE
Fix: Prevent TypeError in gmPerformedHexplorationAction

### DIFF
--- a/foundry-bridge.js
+++ b/foundry-bridge.js
@@ -267,8 +267,9 @@ class HexMapApplication extends Application {
             }
 
             const log = payload.logEntry;
-            let chatMessageContent = `<b>Travel Log:</b> Party ${log.direction.includes('exploring') ? 'explored at' : 'moved ' + log.direction + ' to'} hex ${log.to} (<i>${log.targetTerrain || 'Unknown Terrain'}</i>).<br>`;
-            if (!log.direction.includes('exploring')) {
+            const direction = typeof log.direction === 'string' ? log.direction : '';
+            let chatMessageContent = `<b>Travel Log:</b> Party ${direction.includes('exploring') ? 'explored at' : 'moved ' + direction + ' to'} hex ${log.to} (<i>${log.targetTerrain || 'Unknown Terrain'}</i>).<br>`;
+            if (!direction.includes('exploring')) {
                 chatMessageContent += `Distance: ${log.distanceValue} ${log.distanceUnit || 'units'}. `;
             }
             chatMessageContent += `Base time: ${log.baseTimeValue.toFixed(1)} ${log.baseTimeUnit || 'units'}.<br>`;


### PR DESCRIPTION
Addresses an issue where `log.direction.includes` could cause a TypeError if `log.direction` was undefined or not a string within the `gmPerformedHexplorationAction` message handler.

The fix introduces a `direction` variable that defaults to an empty string if `payload.logEntry.direction` is not a valid string. This ensures that `includes` is always called on a string, preventing the error and allowing chat messages to be generated gracefully even with incomplete log data.