### PR TITLE
feat: Implement travelling animation popup

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -313,6 +313,27 @@ window.addEventListener('message', (event) => {
           }
           break;
 
+        case 'ahnSyncTravelAnimation':
+          // All clients (GM and players) will receive this from foundry-bridge
+          if (payload) {
+            const oldIsActive = appState.travelAnimation.isActive;
+            appState.travelAnimation = { ...appState.travelAnimation, ...payload };
+
+            // GM's client already manages its interval.
+            // Player clients rely on these messages for updates.
+            // If the animation is stopping, ensure local interval is cleared (though players won't have one).
+            if (!appState.isGM && !appState.travelAnimation.isActive && oldIsActive) {
+                // If a player client had some local animation logic (it shouldn't for synced animations), clear it.
+                // For now, map-logic's stopTravelAnimation isn't called on player clients by this message.
+            }
+
+            // If the animation just started for a player, they don't start their own interval.
+            // They just render the state received from the GM.
+
+            renderApp({ preserveScroll: true });
+          }
+          break;
+
         default:
             break;
     }

--- a/app/state.js
+++ b/app/state.js
@@ -71,6 +71,18 @@ export const appState = {
 
   activePartyActivities: new Map(),
 
+  // Travel Animation State
+  travelAnimation: {
+    isActive: false,
+    terrainType: null,
+    terrainName: '',
+    terrainColor: '#FFFFFF',
+    terrainSymbol: '?',
+    markerPosition: 0,
+    startTime: 0,
+    duration: 0,
+  },
+
   // Weather system properties
   isWeatherEnabled: false,
   weatherConditions: [
@@ -118,6 +130,17 @@ export function resetActiveMapState() {
 
     appState.zoomLevel = 1.0;
     appState.activePartyActivities = new Map();
+
+    appState.travelAnimation = {
+      isActive: false,
+      terrainType: null,
+      terrainName: '',
+      terrainColor: '#FFFFFF',
+      terrainSymbol: '?',
+      markerPosition: 0,
+      startTime: 0,
+      duration: 0,
+    };
 
     // Reset weather system properties
     appState.isWeatherEnabled = false;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,4 +1,3 @@
-
 .hexmap-application-window .window-content {
   padding: 0 !important; /* Remove default padding to make iframe fill space */
   overflow: hidden; /* Prevent scrollbars on the window itself */
@@ -13,4 +12,87 @@
 
 .hexmap-app-container iframe {
   flex-grow: 1; /* Iframe takes all available space */
+}
+
+/* Travel Animation Styles */
+.travel-animation-container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(30, 41, 59, 0.9); /* bg-slate-800 with opacity */
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  color: #e5e7eb; /* text-gray-200 */
+  width: 350px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.travel-animation-container.hidden {
+  display: none !important;
+}
+
+.travel-animation-terrain {
+  position: relative;
+  width: 300px;
+  height: 100px;
+  border: 1px solid #4b5563; /* border-gray-600 */
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex; /* For symbol alignment - can be adjusted */
+  flex-wrap: wrap; /* Allow symbols to wrap */
+  padding: 5px; /* Small padding for symbols */
+  align-content: flex-start; /* Align wrapped lines to the start */
+  justify-content: flex-start; /* Align items to the start of each line */
+}
+
+/* Optional: If using rows for terrain symbols as per template */
+.terrain-row {
+  display: flex;
+  width: 100%; /* Ensure rows take full width */
+  justify-content: space-around; /* Example distribution */
+}
+
+.terrain-symbol {
+  font-size: 0.75rem; /* text-xs */
+  opacity: 0.7;
+  margin: 1px; /* Minimal margin for spacing */
+  user-select: none;
+}
+
+.travel-animation-marker {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  background-color: #facc15; /* yellow-400 */
+  border-radius: 50%;
+  border: 2px solid #1f2937; /* gray-800 */
+  box-shadow: 0 0 8px rgba(250, 204, 21, 0.7);
+  transition: left 0.1s linear; /* Smooth movement */
+  z-index: 10; /* Above terrain symbols */
+}
+
+/* Simple party icon using a pseudo-element */
+.travel-animation-marker::before {
+  content: '👥'; /* Example: Group icon */
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.6);
+  color: #1f2937; /* gray-800 */
+  font-size: 18px; /* Adjust size as needed */
+}
+
+
+.travel-animation-info {
+  margin-top: 15px;
+  font-size: 0.875rem; /* text-sm */
+  color: #9ca3af; /* text-gray-400 */
+  text-align: center;
 }

--- a/app/templates/travel-animation.hbs
+++ b/app/templates/travel-animation.hbs
@@ -1,0 +1,15 @@
+<div id="travel-animation-popup" class="travel-animation-container {{#unless isActive}}hidden{{/unless}}">
+  <div class="travel-animation-terrain" style="background-color: {{terrainColor}};">
+    {{#each terrainPatternRows}}
+      <div class="terrain-row">
+        {{#each this}}
+          <span class="terrain-symbol">{{symbol}}</span>
+        {{/each}}
+      </div>
+    {{/each}}
+  </div>
+  <div class="travel-animation-marker" style="left: {{markerPosition}}%;"></div>
+  <div class="travel-animation-info">
+    Travelling through {{terrainName}}...
+  </div>
+</div>

--- a/app/ui.js
+++ b/app/ui.js
@@ -46,6 +46,7 @@ export async function compileTemplates() {
         fetch("templates/controls.hbs"),
         fetch("templates/hex-grid.hbs"),
         fetch("templates/hexagon.hbs"),
+        fetch("templates/travel-animation.hbs"),
     ]);
     for (const res of responses) {
         if (!res.ok) throw new Error( `Failed to fetch template: ${res.url} (${res.status} ${res.statusText})`);
@@ -55,6 +56,7 @@ export async function compileTemplates() {
     Handlebars.registerPartial("controls", texts[1]);
     Handlebars.registerPartial("hexGrid", texts[2]);
     Handlebars.registerPartial("hexagon", texts[3]);
+    Handlebars.registerPartial("travelAnimationPopup", texts[4]);
     Handlebars.registerHelper({
         eq: (a, b) => a === b,
         or: (a, b) => a || b,
@@ -438,6 +440,18 @@ export function renderApp(options = {}) {
         activePartyActivitiesDisplay: activePartyActivitiesDisplayArray, // Used by main.hbs for iterating display
         // activePartyActivitiesCount is no longer explicitly needed here as main.hbs can use activePartyActivities.size (from ...appState)
         // isActivePartyActivity is no longer explicitly needed here as controls.hbs uses lookup on the map for checkbox state (from ...appState)
+        travelAnimation: {
+            isActive: appState.travelAnimation.isActive,
+            terrainColor: appState.travelAnimation.terrainColor,
+            terrainName: appState.travelAnimation.terrainName,
+            markerPosition: appState.travelAnimation.markerPosition,
+            // Generate terrainPatternRows: a 10x20 grid of the terrain symbol
+            terrainPatternRows: Array(10).fill(null).map(() =>
+                Array(20).fill(null).map(() => (
+                    { symbol: appState.travelAnimation.terrainSymbol }
+                ))
+            )
+        },
     };
 
     appContainer.innerHTML = mainTemplateCompiled(renderContext);


### PR DESCRIPTION
Adds a travelling animation popup that appears when the party is travelling. The animation displays a party marker moving across a stylized representation of the terrain.

Key changes:
- Added `travel-animation.hbs` for the popup UI.
- Updated `appState` with `travelAnimation` state.
- Modified `app/ui.js` to render the animation and compile the new template.
- Added `startTravelAnimation`, `updateTravelAnimation`, and `stopTravelAnimation` functions in `app/map-logic.js` to control the animation.
- Integrated the animation start into the `handleHexClick` movement logic in `app/map-logic.js`.
- Implemented state synchronization for the animation between GM and players using `foundry-bridge.js` and `app/app.js`, ensuring all participants see the animation.
- Added CSS styles for the animation popup in `app/styles.css`.

The animation shows a marker moving from left to right over a background filled with the current terrain's symbol and color. The GM's client controls the animation's progression for all players.