### PR TITLE
fix: Ensure travel animation plays in standalone mode

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -348,6 +348,11 @@ async function start() {
     appState.userId = appState.isStandaloneMode ? 'standalone_gm' : (new URLSearchParams(window.location.search).get('userId') || 'unknown_player_iframe');
     appState.appMode = appState.isGM ? CONST.DEFAULT_APP_MODE : CONST.AppMode.PLAYER;
 
+    // Override for standalone mode to ensure GM starts in Player mode
+    if (appState.isStandaloneMode) {
+        appState.appMode = CONST.AppMode.PLAYER;
+    }
+
     const templatesReady = await compileTemplates();
     if (!templatesReady) {
         return;
@@ -373,7 +378,9 @@ async function start() {
         appState.isStandaloneMode = true; 
         appState.isGM = true; 
         appState.userId = 'fallback_standalone_gm';
-        appState.appMode = CONST.DEFAULT_APP_MODE;
+        // appState.appMode = CONST.DEFAULT_APP_MODE; // This would revert our standalone override
+        // Ensure standalone mode also respects the Player mode default for animations
+        appState.appMode = CONST.AppMode.PLAYER;
         MapManagement.handleCreateNewMap(true); 
     }
 }


### PR DESCRIPTION
The travel animation was not appearing in the standalone version of the application. This was because the default application mode (`appMode`) for a GM (which standalone defaults to) was `HEX_EDITOR`. In this mode, map clicks trigger hex editing logic rather than player movement, which is where the travel animation is initiated.

This commit modifies `app/app.js` to explicitly set `appState.appMode` to `PLAYER` when `appState.isStandaloneMode` is true. This ensures that in standalone mode, the GM starts in player mode, allowing map clicks to trigger party travel and the associated travel animation.

The synchronization logic for the animation correctly remains disabled in standalone mode, and the animation now plays locally for you.