### PR TITLE
I've added a new feature to the hex map: you can now implement roads …

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -29,9 +29,33 @@ export const TerrainFeature = {
   NONE: 'none',
   LANDMARK: 'LANDMARK',
   SECRET: 'SECRET',
+  ROAD: 'road',
+  RIVER: 'river',
 };
 
 const TERRAIN_METADATA = {
+  ROAD: {
+    id: 'road', name: 'Road', symbol: '#️⃣', color: 'fill-yellow-600',
+    description: 'A man-made road, offering fast and easy travel.',
+    speedMultiplier: 0.8, visibilityFactor: 1, baseInherentVisibilityBonus: 0, prominence: 0, canopyBlockage: 0,
+    isImpassable: false, blocksLineOfSight: false,
+    colors: { low: 'rgb(202, 138, 4)', mid: 'rgb(212, 148, 14)', high: 'rgb(222, 158, 24)' }, // Example shades of yellow/brown
+    elevationThresholds: { mid: 5, high: 10 }, // Roads typically don't have significant elevation changes themselves
+    encounterChanceOnEnter: 1, // Low chance, maybe bandits
+    encounterChanceOnDiscover: 0
+  },
+  RIVER: {
+    id: 'river', name: 'River', symbol: '〰️', color: 'fill-blue-500',
+    description: 'A flowing body of water, potentially navigable or an obstacle.',
+    speedMultiplier: 1, // Base, depends on how it's interacted with (e.g. swimming, boat)
+    visibilityFactor: 1, baseInherentVisibilityBonus: 0, prominence: 0, canopyBlockage: 0,
+    isImpassable: false, // Assuming it can be crossed or navigated by some means
+    blocksLineOfSight: false, // Water surface doesn't block LoS
+    colors: { low: 'rgb(59, 130, 246)', mid: 'rgb(37, 99, 235)', high: 'rgb(29, 78, 216)' }, // Example shades of blue
+    elevationThresholds: { mid: -10, high: -5 }, // Rivers are typically depressions
+    encounterChanceOnEnter: 3, // River creatures, or people at crossings
+    encounterChanceOnDiscover: 2
+  },
   ROLLING_PLAINS: {
     id: 'rolling_plains', name: 'Rolling Plains', symbol: '🌾', color: 'fill-green-400',
     description: 'Vast, open grasslands with gentle undulations, offering easy travel and clear lines of sight.',

--- a/app/state.js
+++ b/app/state.js
@@ -8,6 +8,11 @@ export const appState = {
   appMode: null,
   viewMode: CONST.DEFAULT_VIEW_MODE,
   
+  // Feature Connection Mode
+  isConnectingFeature: false,
+  connectingFeatureHexId: null,
+  connectingFeatureType: null,
+
   // Hexploration Status
   hexplorationTimeElapsedHoursToday: 0,
   hexplorationKmTraveledToday: 0,
@@ -150,6 +155,9 @@ export function resetActiveMapState() {
     appState.playerDiscoveredHexIds = new Set();
     appState.lastMovementInfo = null;
     appState.isWaitingForFeatureDetails = false;
+    appState.isConnectingFeature = false;
+    appState.connectingFeatureHexId = null;
+    appState.connectingFeatureType = null;
 
   appState.mapDisorientation = {
     isActive: false,

--- a/app/templates/controls.hbs
+++ b/app/templates/controls.hbs
@@ -236,6 +236,15 @@
             Remove Mode
           </button>
         </div>
+
+        {{!-- Connection Mode Feedback --}}
+        {{#if isConnectingFeature}}
+          <div class="mt-1 p-1 bg-sky-700 border border-sky-500 rounded text-center text-xs">
+            <p class="text-white font-semibold">Connecting: {{capitalizeFirst connectingFeatureType}}</p>
+            <p class="text-sky-200">Left-click adjacent hex to connect/disconnect.</p>
+            <p class="text-sky-300">Right-click source hex again or different hex to exit.</p>
+          </div>
+        {{/if}}
       {{/if}}
 
       {{!-- LoS Tools --}}

--- a/app/templates/hexagon.hbs
+++ b/app/templates/hexagon.hbs
@@ -42,6 +42,22 @@
   </filter>
 </defs>
 
+{{! Lines for Roads/Rivers --}}
+{{#if linesToDraw}}
+  {{#each linesToDraw}}
+    <line
+      x1="{{this.x1}}"
+      y1="{{this.y1}}"
+      x2="{{this.x2}}"
+      y2="{{this.y2}}"
+      stroke-width="{{#if (eq this.featureType 'road')}}2.5{{else}}3.5{{/if}}"
+      stroke="{{#if (eq this.featureType 'road')}}#A16207{{! yellow-700 }}{{else}}#2563EB{{! blue-600 }}{{/if}}"
+      {{#if (eq this.featureType 'road')}}stroke-dasharray="4,2"{{/if}}
+      opacity="0.75"
+    />
+  {{/each}}
+{{/if}}
+
 {{! Feature Icons --}}
 {{#if this.featureDisplayIconToRender}}
   {{#if this.isLandmarkFeature}} {{!-- Landmark includes Encounters now --}}


### PR DESCRIPTION
…and rivers with connecting lines!

You can place 'road' and 'river' features on hexes and then create connections between adjacent hexes of the same type. These connections will be visually rendered as lines (dashed brown for roads, solid blue for rivers) on the map.

Here's a summary of the changes I made to your code:
- I added `ROAD` and `RIVER` to `TerrainFeature` and `TERRAIN_METADATA` in `app/constants.js`.
- I updated hex data objects to include a `connections` object for storing directional links.
- I implemented logic in `app/map-logic.js` and `app/ui.js` to:
    - Allow you to right-click on a road/river hex to enter/exit a 'connection mode'.
    - Allow you to left-click on an adjacent, compatible hex (same feature type) while in connection mode to create or remove a two-way connection.
- I modified `app/ui.js` to prepare line data for rendering, ensuring lines are drawn only once for each connection.
- I updated `app/templates/hexagon.hbs` to render these lines as SVG `<line>` elements, styled according to feature type.
- I updated `app/templates/controls.hbs` to include 'Road' and 'River' in the feature selection dropdown and to display a status panel when in connection mode.
- I ensured that connection data is saved and loaded with the map.