### PR TITLE
fix: Correct implementation of roads and rivers as overlay features

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -34,28 +34,6 @@ export const TerrainFeature = {
 };
 
 const TERRAIN_METADATA = {
-  ROAD: {
-    id: 'road', name: 'Road', symbol: '#️⃣', color: 'fill-yellow-600',
-    description: 'A man-made road, offering fast and easy travel.',
-    speedMultiplier: 0.8, visibilityFactor: 1, baseInherentVisibilityBonus: 0, prominence: 0, canopyBlockage: 0,
-    isImpassable: false, blocksLineOfSight: false,
-    colors: { low: 'rgb(202, 138, 4)', mid: 'rgb(212, 148, 14)', high: 'rgb(222, 158, 24)' }, // Example shades of yellow/brown
-    elevationThresholds: { mid: 5, high: 10 }, // Roads typically don't have significant elevation changes themselves
-    encounterChanceOnEnter: 1, // Low chance, maybe bandits
-    encounterChanceOnDiscover: 0
-  },
-  RIVER: {
-    id: 'river', name: 'River', symbol: '〰️', color: 'fill-blue-500',
-    description: 'A flowing body of water, potentially navigable or an obstacle.',
-    speedMultiplier: 1, // Base, depends on how it's interacted with (e.g. swimming, boat)
-    visibilityFactor: 1, baseInherentVisibilityBonus: 0, prominence: 0, canopyBlockage: 0,
-    isImpassable: false, // Assuming it can be crossed or navigated by some means
-    blocksLineOfSight: false, // Water surface doesn't block LoS
-    colors: { low: 'rgb(59, 130, 246)', mid: 'rgb(37, 99, 235)', high: 'rgb(29, 78, 216)' }, // Example shades of blue
-    elevationThresholds: { mid: -10, high: -5 }, // Rivers are typically depressions
-    encounterChanceOnEnter: 3, // River creatures, or people at crossings
-    encounterChanceOnDiscover: 2
-  },
   ROLLING_PLAINS: {
     id: 'rolling_plains', name: 'Rolling Plains', symbol: '🌾', color: 'fill-green-400',
     description: 'Vast, open grasslands with gentle undulations, offering easy travel and clear lines of sight.',

--- a/app/map-logic.js
+++ b/app/map-logic.js
@@ -610,25 +610,29 @@ export async function handleHexClick(row, col, isExploringCurrentHex = false) {
                                 newHexData.featureName = "";
                                 newHexData.featureIcon = null;
                                 newHexData.featureIconColor = null;
+                                // If removing a road/river, connections are implicitly handled by the feature no longer being road/river
                                 hexSpecificChange = true;
                             }
-                        } else if (selectedFeatureTypeConst !== CONST.TerrainFeature.LANDMARK && selectedFeatureTypeConst !== CONST.TerrainFeature.SECRET) {
-                            if (newHexData.feature !== featureTypeToApplyLower) {
-                                newHexData.feature = featureTypeToApplyLower;
-                                newHexData.featureName = ""; // Clear name/icon for non-landmark/secret
+                        } else if (selectedFeatureTypeConst === CONST.TerrainFeature.ROAD || selectedFeatureTypeConst === CONST.TerrainFeature.RIVER) {
+                            const featureToApply = selectedFeatureTypeConst.toLowerCase();
+                            if (newHexData.feature !== featureToApply) {
+                                newHexData.feature = featureToApply;
+                                newHexData.featureName = "";
                                 newHexData.featureIcon = null;
                                 newHexData.featureIconColor = null;
-                                // Ensure .connections object exists if placing a connectable feature
-                                if (featureTypeToApplyLower === CONST.TerrainFeature.ROAD || featureTypeToApplyLower === CONST.TerrainFeature.RIVER) {
-                                    if (!newHexData.connections) {
-                                        newHexData.connections = {};
-                                    }
-                                } else {
-                                    // If changing from a connectable feature to a non-connectable one,
-                                    // and the hex had connections, those connections might become orphaned.
-                                    // For now, we are not automatically clearing them here, but it's a consideration.
-                                    // The main thing is to ensure .connections exists if it *is* a road/river.
-                                }
+                                newHexData.connections = newHexData.connections || {}; // Ensure connections object exists
+                                hexSpecificChange = true;
+                            }
+                        } else { // For any other future simple features that don't need a dialog
+                            // This branch ensures any other non-LANDMARK, non-SECRET, non-NONE, non-ROAD/RIVER feature type
+                            // would also be applied simply, without a dialog.
+                            const featureToApply = selectedFeatureTypeConst.toLowerCase();
+                            if (newHexData.feature !== featureToApply) {
+                                newHexData.feature = featureToApply;
+                                newHexData.featureName = "";
+                                newHexData.featureIcon = null;
+                                newHexData.featureIconColor = null;
+                                // newHexData.connections = newHexData.connections || {}; // Decide if other simple features use connections
                                 hexSpecificChange = true;
                             }
                         }


### PR DESCRIPTION
This commit corrects the previous implementation where roads and rivers were erroneously added as base terrain types. They are now correctly implemented as overlay features, similar to landmarks or secrets, but with the ability to draw connecting lines.

Corrections include:
- Removed ROAD and RIVER definitions from `TERRAIN_METADATA` in `app/constants.js`. They remain correctly defined in `CONST.TerrainFeature`.
- Adjusted feature placement logic in `app/map-logic.js` to ensure that placing a road or river sets the `hex.feature` property without changing the underlying `hex.terrain` and without triggering the details dialog.
- Verified that the existing connection logic (right-click for connection mode, left-click to connect/disconnect) and line rendering logic correctly support roads/rivers as features.
- Verified UI controls and data persistence for the corrected approach.

Roads and rivers can now be painted onto hexes, and lines can be drawn between adjacent hexes of the same type to represent paths.